### PR TITLE
Ensure warning level 0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .Ruserdata
 .DS_Store
 inst/doc
+CRAN-RELEASE

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: errorist
 Title: Automatically Search Errors or Warnings
-Version: 0.0.3
+Version: 0.0.3.9000
 Authors@R: c(
              person("James", "Balamuta", 
                     email = "balamut2@illinois.edu", 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,14 @@
+# errorist 0.0.3.9000
+
+## Fixes
+
+- Ensured the `last.warning` object was created by setting `options('warn' = 0)`,
+  which is the default value. Upon unload, the warning level is restored to
+  the old value.
+  
 # errorist 0.0.3
 
-## Bug Fix
+## Fixes
 
 - Address an erroneous unit test that was comparing functions within namespaces
   instead of environments.

--- a/R/handlers.R
+++ b/R/handlers.R
@@ -171,6 +171,7 @@ disable_warning_shim = function() {
   # Reset the warning
   .errorist_env$captured_last_search_warning = NULL
 
+  print(.errorist_env$warn_level)
   # Restore original warning level
   options("warn" = .errorist_env$warn_level)
 

--- a/R/handlers.R
+++ b/R/handlers.R
@@ -1,6 +1,3 @@
-# Package Environment
-.errorist_env = new.env()
-
 #' Enable or Disable Errorist's Automatic Search
 #'
 #' Activates or disengages the automatic look up of error or warning codes in
@@ -156,6 +153,12 @@ enable_warning_shim = function(warning_search_func =
   # No warning messages yet (we hope!)
   .errorist_env$captured_last_search_warning = NA
 
+  # Restore to default setting to ensure `last.warning` is created.
+  warn_level = getOption("warn", 0)
+  if (warn_level != 0) {
+    options("warn" = 0)
+  }
+
   # Automatically call the warning_handler after each R function is run
   handler = addTaskCallback(warning_handler(warning_search_func),
                             name = "ErroristWarningHandler")
@@ -167,6 +170,9 @@ enable_warning_shim = function(warning_search_func =
 disable_warning_shim = function() {
   # Reset the warning
   .errorist_env$captured_last_search_warning = NULL
+
+  # Restore original warning level
+  options("warn" = .errorist_env$warn_level)
 
   # Remove handler
   removed_handler = removeTaskCallback("ErroristWarningHandler")
@@ -197,9 +203,6 @@ enable_error_shim = function(error_search_func =
   # Remove the shim if it exists...
   disable_error_shim()
 
-  # Save present options
-  .errorist_env$op = options()
-
   # Errorist
   op.errorist = list(error = error_search_func)
 
@@ -210,17 +213,13 @@ enable_error_shim = function(error_search_func =
 #' @rdname shims
 #' @export
 disable_error_shim = function() {
-  # Restore options
-  if (exists("op", envir = .errorist_env) &&
-      is.null(.errorist_env$op)) {
-    # Empty if condition...
 
-  } else if ("error" %in% names(.errorist_env$op)) {
+  # Restore options
+  if ("error" %in% names(.errorist_env$op)) {
     options(.errorist_env$op)
   } else {
     # Ensure error is nullified.
     options(error = NULL)
   }
 
-  .errorist_env$op = NULL
 }

--- a/R/handlers.R
+++ b/R/handlers.R
@@ -171,7 +171,6 @@ disable_warning_shim = function() {
   # Reset the warning
   .errorist_env$captured_last_search_warning = NULL
 
-  print(.errorist_env$warn_level)
   # Restore original warning level
   options("warn" = .errorist_env$warn_level)
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,6 +1,16 @@
+# Package Environment
+.errorist_env = new.env()
+
+# Retrieve settings on load
+setup_errorist_environment = function() {
+  .errorist_env$op = options()
+  .errorist_env$warn_level = getOption("warn", 0)
+}
+
 .onAttach = function(libname, pkgname) {
 
   autoload_config = getOption("errorist.autoload", TRUE)
+  setup_errorist_environment()
 
   if(!is.logical(autoload_config)) {
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,10 +1,11 @@
 # Package Environment
 .errorist_env = new.env()
+.errorist_env$warn_level = 0
 
 # Retrieve settings on load
 setup_errorist_environment = function() {
   .errorist_env$op = options()
-  .errorist_env$warn_level = getOption("warn", 0)
+  .errorist_env$warn_level =  getOption("warn", 0)
 }
 
 .onAttach = function(libname, pkgname) {


### PR DESCRIPTION
This PR ensure that the `last.warning` object is created by restoring the default value for `option('warn' = 0)`. Note: Some users may use `option('warn' = 1)`, which causes the warning to be displayed but not retained. 